### PR TITLE
Fix setTrait Return Type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -57,7 +57,7 @@ declare module 'flagsmith-nodejs' {
         userId: string,
         key: string,
         value: string | number | boolean
-    ): IUserIdentity;
+    ): Promise<IUserIdentity>;
 
     interface IFeature {
         enabled: boolean;


### PR DESCRIPTION
The `setTrait` method returns a promise but the interface makes it look like a synchronous operation. This could lead to race conditions if the call is not awaited before a `getValue` with a userId is executed.